### PR TITLE
Fixed broken tools/typings exclude/include patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,10 @@
 Icon
 
 node_modules
-tools/typings
+!tools/typings
+tools/typings/*
 !tools/typings/tsd.d.ts
-!tools/typings/expenseApp.d.ts
+!tools/typings/typescriptApp.d.ts
 **/bower_packages
 
 # all generated JS


### PR DESCRIPTION
I fixed up the gitignore file so that the tools/typings/tsd.d.ts and typescriptApp.d.ts files are included
